### PR TITLE
[18기 배담호] Add: 리뷰반영 및 메인 페이지네이션 기능 구현완료, 정렬기능 구현완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.3",
         "styled-components": "^5.2.1",
+        "styled-icons": "^10.31.0",
         "styled-reset": "^4.3.4",
         "tig": "^0.1.43",
         "web-vitals": "^1.1.1"
@@ -2462,6 +2463,786 @@
       "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@styled-icons/bootstrap": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/bootstrap/-/bootstrap-10.29.0.tgz",
+      "integrity": "sha512-B6UhU2p8zpAKBMLDmxgoXlHbODrvz8MM8nRLIGpCIWJ8rMen6a1FQJj22vKOL4ppC4A0hy2/IgBEc1gVwOdwiw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/bootstrap/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-logos": {
+      "version": "10.23.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-logos/-/boxicons-logos-10.23.0.tgz",
+      "integrity": "sha512-TC6to8kfSY7pVwvOv0a8kboYH7nF69/uxCOZnrpZlzJbeZGsnIt2sAPRSV8454wXfsZ75pVcprCv26RO9aNHVA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-logos/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-regular": {
+      "version": "10.23.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-regular/-/boxicons-regular-10.23.0.tgz",
+      "integrity": "sha512-cVBXsgDzC9lZOhBaurxJcgiRpl3mMxNHsD0+PKi23yaEU20zIyBPjRgVw+qaqKKAUNONDkWej1vwiL5KericPw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-regular/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-solid": {
+      "version": "10.23.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-solid/-/boxicons-solid-10.23.0.tgz",
+      "integrity": "sha512-W7/NpBJ6Y2hEwSEYDZz6Rw97j1f4y0dd1lEZsgSIit0DjRpESt7t15ptMLf3zXnFVmrphHn9XRN3lyF6R8Gdtw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/boxicons-solid/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/crypto": {
+      "version": "10.25.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/crypto/-/crypto-10.25.0.tgz",
+      "integrity": "sha512-WjURyH6wmE835D674KgpK87nU6kJSkA4XV5C/SP5dc+0FeUKeRm0FegX0Pakaqjj4pvFrBqeeS8Kg24IMUmHgA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/crypto/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/entypo": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo/-/entypo-10.18.0.tgz",
+      "integrity": "sha512-FZdYzBiqXgas/c76eeCSWfEy6jpzfvucIXMgwsTDQioh7/x9qVmuyz5TVlghx2zWmtoz4hEnLIDD0Yzw1ajXWQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/entypo-social": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo-social/-/entypo-social-10.18.0.tgz",
+      "integrity": "sha512-JjDRJrsLi2IhjPBLYPJW+SNOijcOAOHu6ulyEJmtIRCKGzwdFJaXFPVxhULDnsr1vwBlxYdyvpz72liZH1gZpw==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/evaicons-outline": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-outline/-/evaicons-outline-10.18.0.tgz",
+      "integrity": "sha512-6D352LtvtzfHlhxgUeair6NPfyJ0y6V+1r710w1qoEVO/mnc9F+ED6MaOCDv8GeDOM3eCPd8y2Fs6EA8zKuv/A==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/evaicons-solid": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-solid/-/evaicons-solid-10.18.0.tgz",
+      "integrity": "sha512-vL1zGDTj2Mp/RedOaEkm5Ni9/h5scY5VQbwTQFnMV+QcLzk+WKCvS3Jj8mbqbEWvL4MtCdJYDC0UPD4sZSHV5A==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/evil": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evil/-/evil-10.18.0.tgz",
+      "integrity": "sha512-WeBvdVbMg4qYp7pu21FDyJgDekeNF46B9nkyQFYymEQG95AndZArFPOUzshflBcGKB6xv2+jVyPtbtcHh2oQOA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fa-brands": {
+      "version": "10.26.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-brands/-/fa-brands-10.26.0.tgz",
+      "integrity": "sha512-1J2Pac3QwxArDzI/EAibLlTQ+4mFr7e6ZIVdLT+hmQrTQ+2Ibm403fHwsEBvLYzCI/7XQERPcxy1uBdkSgrKXw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fa-brands/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/fa-regular": {
+      "version": "10.26.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-regular/-/fa-regular-10.26.0.tgz",
+      "integrity": "sha512-aazl9vntOe16g6Qj6qBH91oLH1i2XMKEu7gjDRiUwxoGIm0GVzJGIi1Qa8ENvfYI9h8f85sghA2GH3Db4wOteA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fa-regular/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/fa-solid": {
+      "version": "10.26.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-solid/-/fa-solid-10.26.0.tgz",
+      "integrity": "sha512-59/2KbnaP2euOR6UvZd1hncLvPTWJ1iT4Ohu7SV6tEvivDY/e2+uRMZiQlUgAGhzkmzQwYDeftaoiQaZeIfa4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fa-solid/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/feather": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/feather/-/feather-10.18.0.tgz",
+      "integrity": "sha512-W8ESG+KLaiCekydTV6LaP3FW5enwvGMSM2T/wvS8HPmnR6tFb4hn8VQrtXG8Bwdc5RmTJ+2eyN6N3KySMfMC4Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fluentui-system-filled": {
+      "version": "10.30.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-filled/-/fluentui-system-filled-10.30.0.tgz",
+      "integrity": "sha512-GxLG44rY/Th/bzQFVeJQCG7+DTewdMVL/RbtX3RYhrmfHJCTVozKpprG1F3J+UIbH8b3BsZO5nHa9loY9GNzBA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fluentui-system-filled/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/fluentui-system-regular": {
+      "version": "10.31.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-regular/-/fluentui-system-regular-10.31.0.tgz",
+      "integrity": "sha512-GsEkAhW5wiqTXlLMMEZ5wso6GoEOAPyWwI4iUPFao2u3bLCCoxvklB5mV2YBe+VfA85u/tS/gnV5p+jneojssQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/fluentui-system-regular/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/foundation": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/foundation/-/foundation-10.28.0.tgz",
+      "integrity": "sha512-hilmafnCFjV6d4cnmmee0qv2wkqAYC3KIDGf3MNRhRiSRTlpAxi22nXC2ax+Ta9qKRI11o+gdPhjAKA6J/AEsQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/foundation/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/heroicons-outline": {
+      "version": "10.19.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-outline/-/heroicons-outline-10.19.0.tgz",
+      "integrity": "sha512-iJsSidfi3VqSLGHA3eECSBB8/j+zxV4q2sm21/DiRZZ4UhxBVnySECaHZfSeQ8qafe51+zIR+0oOs4qJAeGCyQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/heroicons-solid": {
+      "version": "10.19.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-solid/-/heroicons-solid-10.19.0.tgz",
+      "integrity": "sha512-s72o12IOKyEOkRSWFqAX6Y/Od6i0ivdP7yl7nlXG9WZNiuU97FasfwS4YS4nw3kmrkM5P00EqlMuHokv4aq7TA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/icomoon": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/icomoon/-/icomoon-10.18.0.tgz",
+      "integrity": "sha512-4a+j4+zkhfroUiT/4wjFuMJlhL4mvauyKVXZPZPsaRkkhdgWXkfYBy9j9DwA1ETaK+7aZep9Ng3EqHHeOF5bbg==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-outline": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-outline/-/ionicons-outline-10.28.0.tgz",
+      "integrity": "sha512-/yoZJa6nB/aXTOYobj6D9gE0JWejKrLmAGfdiUiqMX9exp4XeVxLPNaIbO2ilP/2VzGUAJJxh/KYMFIzoy5tkQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-outline/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-sharp": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-sharp/-/ionicons-sharp-10.28.0.tgz",
+      "integrity": "sha512-5Qw8BMwvyAj0uzrPQ2BbbMVS8nrT164tIWoHyg/z4GXBKiiXukMoNJ+Z+sScG8+HLE+dc2SOzzX0+luSX7Ix6A==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-sharp/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-solid": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-solid/-/ionicons-solid-10.28.0.tgz",
+      "integrity": "sha512-vtnJzTDzVfPAt6PNOuUUTTzXwwoDqe3u6srzo/WZGc6wh0UEoNgs65pqiAwaG8RyJvfufJ0rMr2yDJRTWBddUA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/ionicons-solid/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/material": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material/-/material-10.28.0.tgz",
+      "integrity": "sha512-+401y79/qclNEMVbkAy98sJbBazeX/0k0DuPsULikAa+GDmmfzwk+xi9HloQa1Gsyc9/Zbnc5Hf7rFiJcukfbA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-outlined": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-outlined/-/material-outlined-10.28.0.tgz",
+      "integrity": "sha512-TXCYrBeR5YXDziNMDAO6ZpKVjWvWaWmhBvF/vTvL6sME5zazk9sToyRJ6i/+DZGNH8wD7+635e8hkZAYPp++/A==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-outlined/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/material-rounded": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-rounded/-/material-rounded-10.28.0.tgz",
+      "integrity": "sha512-qNnsrkdAwSaiakh7xPVVucP0XnDQ0UwaODpQ1cxASZ6+7XPJHsOxYd+VTTSn3h99Unzp4QJltrBaz//Ky6zSGw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-rounded/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/material-sharp": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-sharp/-/material-sharp-10.28.0.tgz",
+      "integrity": "sha512-bII2ZotBYFFO982hKoVZ6A6iQQDooV8PeVbfuveUqK9MO7sDYZ0aPFKv4vMYVpVgfJWpoWekigHhCW8eoSnGUg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-sharp/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/material-twotone": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-twotone/-/material-twotone-10.28.0.tgz",
+      "integrity": "sha512-dpkHg477fipvehVJdDOpNcFWXmL4M2PBscfm61lYsnscDvIzRK0GJ1Rzmv2QiW48DSO02FSxaoRIdBm2bjZLfg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/material-twotone/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/material/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/octicons": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/octicons/-/octicons-10.28.0.tgz",
+      "integrity": "sha512-j53tBXtNB4v5qD9lCFJJ2mcOBiAWXuySItRfU7lpMqJhvrfbfqMgMTdmPR+Ak3sbSqWaV7qNhs3+zvsGPtM5iw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/octicons/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/open-iconic": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/open-iconic/-/open-iconic-10.18.0.tgz",
+      "integrity": "sha512-H+uiRUDm09SXlOgJheOmhT0KeLs5uBS85H2VF1ypMN1m/vy/NdaGP5QAvWTCzBk088JJGYEkvhb4i4pGcwRsEA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/remix-fill": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-fill/-/remix-fill-10.18.0.tgz",
+      "integrity": "sha512-FbnQMvxt2R7CYb8j/dVAXd31CDg4k3vX1zG/9GH9qpL536yxndnyopa7hwF/Yisy2pzR7uNlNXmTQAmYK2HSrg==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/remix-line": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-line/-/remix-line-10.18.0.tgz",
+      "integrity": "sha512-UZllhk6hEWFyZt+jdPCO4zbeM0P3Y/Lc1iWWOwUXGP5AzStM2KadjaGpi99FhNfrvrly98cVB8b4M/GVExYn0Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/simple-icons": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/simple-icons/-/simple-icons-10.29.0.tgz",
+      "integrity": "sha512-TkNb6HII1xjmjlapY2msn8G+neLs6XYA3IclSR19Te5BLM8Su+Ct2unArSXoQym9W+SeiMnfjPI0dkAj9zY/Rw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/simple-icons/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "node_modules/@styled-icons/styled-icon": {
+      "version": "10.6.3",
+      "resolved": "https://registry.npmjs.org/@styled-icons/styled-icon/-/styled-icon-10.6.3.tgz",
+      "integrity": "sha512-/A95L3peioLoWFiy+/eKRhoQ9r/oRrN/qzbSX4hXU1nGP2rUXcX3LWUhoBNAOp9Rw38ucc/4ralY427UUNtcGQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@emotion/is-prop-valid": "^0.8.7"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": ">=4.1.0 <6"
+      }
+    },
+    "node_modules/@styled-icons/typicons": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/typicons/-/typicons-10.18.0.tgz",
+      "integrity": "sha512-VN9vEzeAn5//uUvBN2N/OAXnrC6zCERu1eXUiXmYTwd7n8ZoMMASKmVWrAho20YmhUjEPZdSvS1cJ/pzV9K6Zg==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
+      }
+    },
+    "node_modules/@styled-icons/zondicons": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/zondicons/-/zondicons-10.18.0.tgz",
+      "integrity": "sha512-P+XDzHRjY7zgcOYI22VJPg4GW01760VICwMSF2vJFRd0bux3hKIJI8voABA9v00Ce1TeOZnUbKcgQFBNIThs5w==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": "*"
       }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
@@ -18718,6 +19499,66 @@
         "react-is": ">= 16.8.0"
       }
     },
+    "node_modules/styled-icons": {
+      "version": "10.31.0",
+      "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-10.31.0.tgz",
+      "integrity": "sha512-cBrmKImC80kl5Pf42NOhY+LkKbdYDqFocs+pAdwDrnUtu2j70ZJJoCZ6jDR1F0cCMCZ1dAAPO0OzN3+5KeeheA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@styled-icons/bootstrap": "10.29.0",
+        "@styled-icons/boxicons-logos": "10.23.0",
+        "@styled-icons/boxicons-regular": "10.23.0",
+        "@styled-icons/boxicons-solid": "10.23.0",
+        "@styled-icons/crypto": "10.25.0",
+        "@styled-icons/entypo": "10.18.0",
+        "@styled-icons/entypo-social": "10.18.0",
+        "@styled-icons/evaicons-outline": "10.18.0",
+        "@styled-icons/evaicons-solid": "10.18.0",
+        "@styled-icons/evil": "10.18.0",
+        "@styled-icons/fa-brands": "10.26.0",
+        "@styled-icons/fa-regular": "10.26.0",
+        "@styled-icons/fa-solid": "10.26.0",
+        "@styled-icons/feather": "10.18.0",
+        "@styled-icons/fluentui-system-filled": "10.30.0",
+        "@styled-icons/fluentui-system-regular": "10.31.0",
+        "@styled-icons/foundation": "10.28.0",
+        "@styled-icons/heroicons-outline": "10.19.0",
+        "@styled-icons/heroicons-solid": "10.19.0",
+        "@styled-icons/icomoon": "10.18.0",
+        "@styled-icons/ionicons-outline": "10.28.0",
+        "@styled-icons/ionicons-sharp": "10.28.0",
+        "@styled-icons/ionicons-solid": "10.28.0",
+        "@styled-icons/material": "10.28.0",
+        "@styled-icons/material-outlined": "10.28.0",
+        "@styled-icons/material-rounded": "10.28.0",
+        "@styled-icons/material-sharp": "10.28.0",
+        "@styled-icons/material-twotone": "10.28.0",
+        "@styled-icons/octicons": "10.28.0",
+        "@styled-icons/open-iconic": "10.18.0",
+        "@styled-icons/remix-fill": "10.18.0",
+        "@styled-icons/remix-line": "10.18.0",
+        "@styled-icons/simple-icons": "10.29.0",
+        "@styled-icons/styled-icon": "10.6.3",
+        "@styled-icons/typicons": "10.18.0",
+        "@styled-icons/zondicons": "10.18.0"
+      },
+      "funding": {
+        "type": "GitHub",
+        "url": "https://github.com/sponsors/jacobwgillespie"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "styled-components": ">=4.1.0 <6"
+      }
+    },
+    "node_modules/styled-icons/node_modules/@babel/runtime": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+      "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "node_modules/styled-reset": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/styled-reset/-/styled-reset-4.3.4.tgz",
@@ -23699,6 +24540,540 @@
       "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@styled-icons/bootstrap": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/bootstrap/-/bootstrap-10.29.0.tgz",
+      "integrity": "sha512-B6UhU2p8zpAKBMLDmxgoXlHbODrvz8MM8nRLIGpCIWJ8rMen6a1FQJj22vKOL4ppC4A0hy2/IgBEc1gVwOdwiw==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/boxicons-logos": {
+      "version": "10.23.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-logos/-/boxicons-logos-10.23.0.tgz",
+      "integrity": "sha512-TC6to8kfSY7pVwvOv0a8kboYH7nF69/uxCOZnrpZlzJbeZGsnIt2sAPRSV8454wXfsZ75pVcprCv26RO9aNHVA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/boxicons-regular": {
+      "version": "10.23.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-regular/-/boxicons-regular-10.23.0.tgz",
+      "integrity": "sha512-cVBXsgDzC9lZOhBaurxJcgiRpl3mMxNHsD0+PKi23yaEU20zIyBPjRgVw+qaqKKAUNONDkWej1vwiL5KericPw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/boxicons-solid": {
+      "version": "10.23.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/boxicons-solid/-/boxicons-solid-10.23.0.tgz",
+      "integrity": "sha512-W7/NpBJ6Y2hEwSEYDZz6Rw97j1f4y0dd1lEZsgSIit0DjRpESt7t15ptMLf3zXnFVmrphHn9XRN3lyF6R8Gdtw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/crypto": {
+      "version": "10.25.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/crypto/-/crypto-10.25.0.tgz",
+      "integrity": "sha512-WjURyH6wmE835D674KgpK87nU6kJSkA4XV5C/SP5dc+0FeUKeRm0FegX0Pakaqjj4pvFrBqeeS8Kg24IMUmHgA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/entypo": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo/-/entypo-10.18.0.tgz",
+      "integrity": "sha512-FZdYzBiqXgas/c76eeCSWfEy6jpzfvucIXMgwsTDQioh7/x9qVmuyz5TVlghx2zWmtoz4hEnLIDD0Yzw1ajXWQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/entypo-social": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/entypo-social/-/entypo-social-10.18.0.tgz",
+      "integrity": "sha512-JjDRJrsLi2IhjPBLYPJW+SNOijcOAOHu6ulyEJmtIRCKGzwdFJaXFPVxhULDnsr1vwBlxYdyvpz72liZH1gZpw==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/evaicons-outline": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-outline/-/evaicons-outline-10.18.0.tgz",
+      "integrity": "sha512-6D352LtvtzfHlhxgUeair6NPfyJ0y6V+1r710w1qoEVO/mnc9F+ED6MaOCDv8GeDOM3eCPd8y2Fs6EA8zKuv/A==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/evaicons-solid": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evaicons-solid/-/evaicons-solid-10.18.0.tgz",
+      "integrity": "sha512-vL1zGDTj2Mp/RedOaEkm5Ni9/h5scY5VQbwTQFnMV+QcLzk+WKCvS3Jj8mbqbEWvL4MtCdJYDC0UPD4sZSHV5A==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/evil": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/evil/-/evil-10.18.0.tgz",
+      "integrity": "sha512-WeBvdVbMg4qYp7pu21FDyJgDekeNF46B9nkyQFYymEQG95AndZArFPOUzshflBcGKB6xv2+jVyPtbtcHh2oQOA==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/fa-brands": {
+      "version": "10.26.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-brands/-/fa-brands-10.26.0.tgz",
+      "integrity": "sha512-1J2Pac3QwxArDzI/EAibLlTQ+4mFr7e6ZIVdLT+hmQrTQ+2Ibm403fHwsEBvLYzCI/7XQERPcxy1uBdkSgrKXw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/fa-regular": {
+      "version": "10.26.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-regular/-/fa-regular-10.26.0.tgz",
+      "integrity": "sha512-aazl9vntOe16g6Qj6qBH91oLH1i2XMKEu7gjDRiUwxoGIm0GVzJGIi1Qa8ENvfYI9h8f85sghA2GH3Db4wOteA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/fa-solid": {
+      "version": "10.26.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fa-solid/-/fa-solid-10.26.0.tgz",
+      "integrity": "sha512-59/2KbnaP2euOR6UvZd1hncLvPTWJ1iT4Ohu7SV6tEvivDY/e2+uRMZiQlUgAGhzkmzQwYDeftaoiQaZeIfa4w==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/feather": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/feather/-/feather-10.18.0.tgz",
+      "integrity": "sha512-W8ESG+KLaiCekydTV6LaP3FW5enwvGMSM2T/wvS8HPmnR6tFb4hn8VQrtXG8Bwdc5RmTJ+2eyN6N3KySMfMC4Q==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/fluentui-system-filled": {
+      "version": "10.30.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-filled/-/fluentui-system-filled-10.30.0.tgz",
+      "integrity": "sha512-GxLG44rY/Th/bzQFVeJQCG7+DTewdMVL/RbtX3RYhrmfHJCTVozKpprG1F3J+UIbH8b3BsZO5nHa9loY9GNzBA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/fluentui-system-regular": {
+      "version": "10.31.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/fluentui-system-regular/-/fluentui-system-regular-10.31.0.tgz",
+      "integrity": "sha512-GsEkAhW5wiqTXlLMMEZ5wso6GoEOAPyWwI4iUPFao2u3bLCCoxvklB5mV2YBe+VfA85u/tS/gnV5p+jneojssQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/foundation": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/foundation/-/foundation-10.28.0.tgz",
+      "integrity": "sha512-hilmafnCFjV6d4cnmmee0qv2wkqAYC3KIDGf3MNRhRiSRTlpAxi22nXC2ax+Ta9qKRI11o+gdPhjAKA6J/AEsQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/heroicons-outline": {
+      "version": "10.19.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-outline/-/heroicons-outline-10.19.0.tgz",
+      "integrity": "sha512-iJsSidfi3VqSLGHA3eECSBB8/j+zxV4q2sm21/DiRZZ4UhxBVnySECaHZfSeQ8qafe51+zIR+0oOs4qJAeGCyQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/heroicons-solid": {
+      "version": "10.19.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/heroicons-solid/-/heroicons-solid-10.19.0.tgz",
+      "integrity": "sha512-s72o12IOKyEOkRSWFqAX6Y/Od6i0ivdP7yl7nlXG9WZNiuU97FasfwS4YS4nw3kmrkM5P00EqlMuHokv4aq7TA==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/icomoon": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/icomoon/-/icomoon-10.18.0.tgz",
+      "integrity": "sha512-4a+j4+zkhfroUiT/4wjFuMJlhL4mvauyKVXZPZPsaRkkhdgWXkfYBy9j9DwA1ETaK+7aZep9Ng3EqHHeOF5bbg==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/ionicons-outline": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-outline/-/ionicons-outline-10.28.0.tgz",
+      "integrity": "sha512-/yoZJa6nB/aXTOYobj6D9gE0JWejKrLmAGfdiUiqMX9exp4XeVxLPNaIbO2ilP/2VzGUAJJxh/KYMFIzoy5tkQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/ionicons-sharp": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-sharp/-/ionicons-sharp-10.28.0.tgz",
+      "integrity": "sha512-5Qw8BMwvyAj0uzrPQ2BbbMVS8nrT164tIWoHyg/z4GXBKiiXukMoNJ+Z+sScG8+HLE+dc2SOzzX0+luSX7Ix6A==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/ionicons-solid": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/ionicons-solid/-/ionicons-solid-10.28.0.tgz",
+      "integrity": "sha512-vtnJzTDzVfPAt6PNOuUUTTzXwwoDqe3u6srzo/WZGc6wh0UEoNgs65pqiAwaG8RyJvfufJ0rMr2yDJRTWBddUA==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/material": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material/-/material-10.28.0.tgz",
+      "integrity": "sha512-+401y79/qclNEMVbkAy98sJbBazeX/0k0DuPsULikAa+GDmmfzwk+xi9HloQa1Gsyc9/Zbnc5Hf7rFiJcukfbA==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/material-outlined": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-outlined/-/material-outlined-10.28.0.tgz",
+      "integrity": "sha512-TXCYrBeR5YXDziNMDAO6ZpKVjWvWaWmhBvF/vTvL6sME5zazk9sToyRJ6i/+DZGNH8wD7+635e8hkZAYPp++/A==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/material-rounded": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-rounded/-/material-rounded-10.28.0.tgz",
+      "integrity": "sha512-qNnsrkdAwSaiakh7xPVVucP0XnDQ0UwaODpQ1cxASZ6+7XPJHsOxYd+VTTSn3h99Unzp4QJltrBaz//Ky6zSGw==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/material-sharp": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-sharp/-/material-sharp-10.28.0.tgz",
+      "integrity": "sha512-bII2ZotBYFFO982hKoVZ6A6iQQDooV8PeVbfuveUqK9MO7sDYZ0aPFKv4vMYVpVgfJWpoWekigHhCW8eoSnGUg==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/material-twotone": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/material-twotone/-/material-twotone-10.28.0.tgz",
+      "integrity": "sha512-dpkHg477fipvehVJdDOpNcFWXmL4M2PBscfm61lYsnscDvIzRK0GJ1Rzmv2QiW48DSO02FSxaoRIdBm2bjZLfg==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/octicons": {
+      "version": "10.28.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/octicons/-/octicons-10.28.0.tgz",
+      "integrity": "sha512-j53tBXtNB4v5qD9lCFJJ2mcOBiAWXuySItRfU7lpMqJhvrfbfqMgMTdmPR+Ak3sbSqWaV7qNhs3+zvsGPtM5iw==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/open-iconic": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/open-iconic/-/open-iconic-10.18.0.tgz",
+      "integrity": "sha512-H+uiRUDm09SXlOgJheOmhT0KeLs5uBS85H2VF1ypMN1m/vy/NdaGP5QAvWTCzBk088JJGYEkvhb4i4pGcwRsEA==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/remix-fill": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-fill/-/remix-fill-10.18.0.tgz",
+      "integrity": "sha512-FbnQMvxt2R7CYb8j/dVAXd31CDg4k3vX1zG/9GH9qpL536yxndnyopa7hwF/Yisy2pzR7uNlNXmTQAmYK2HSrg==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/remix-line": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/remix-line/-/remix-line-10.18.0.tgz",
+      "integrity": "sha512-UZllhk6hEWFyZt+jdPCO4zbeM0P3Y/Lc1iWWOwUXGP5AzStM2KadjaGpi99FhNfrvrly98cVB8b4M/GVExYn0Q==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/simple-icons": {
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/simple-icons/-/simple-icons-10.29.0.tgz",
+      "integrity": "sha512-TkNb6HII1xjmjlapY2msn8G+neLs6XYA3IclSR19Te5BLM8Su+Ct2unArSXoQym9W+SeiMnfjPI0dkAj9zY/Rw==",
+      "requires": {
+        "@babel/runtime": "^7.12.13",
+        "@styled-icons/styled-icon": "^10.6.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@styled-icons/styled-icon": {
+      "version": "10.6.3",
+      "resolved": "https://registry.npmjs.org/@styled-icons/styled-icon/-/styled-icon-10.6.3.tgz",
+      "integrity": "sha512-/A95L3peioLoWFiy+/eKRhoQ9r/oRrN/qzbSX4hXU1nGP2rUXcX3LWUhoBNAOp9Rw38ucc/4ralY427UUNtcGQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@emotion/is-prop-valid": "^0.8.7"
+      }
+    },
+    "@styled-icons/typicons": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/typicons/-/typicons-10.18.0.tgz",
+      "integrity": "sha512-VN9vEzeAn5//uUvBN2N/OAXnrC6zCERu1eXUiXmYTwd7n8ZoMMASKmVWrAho20YmhUjEPZdSvS1cJ/pzV9K6Zg==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
+      }
+    },
+    "@styled-icons/zondicons": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@styled-icons/zondicons/-/zondicons-10.18.0.tgz",
+      "integrity": "sha512-P+XDzHRjY7zgcOYI22VJPg4GW01760VICwMSF2vJFRd0bux3hKIJI8voABA9v00Ce1TeOZnUbKcgQFBNIThs5w==",
+      "requires": {
+        "@babel/runtime": "^7.10.5",
+        "@styled-icons/styled-icon": "^10.6.0"
       }
     },
     "@surma/rollup-plugin-off-main-thread": {
@@ -36421,6 +37796,60 @@
         "hoist-non-react-statics": "^3.0.0",
         "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
+      }
+    },
+    "styled-icons": {
+      "version": "10.31.0",
+      "resolved": "https://registry.npmjs.org/styled-icons/-/styled-icons-10.31.0.tgz",
+      "integrity": "sha512-cBrmKImC80kl5Pf42NOhY+LkKbdYDqFocs+pAdwDrnUtu2j70ZJJoCZ6jDR1F0cCMCZ1dAAPO0OzN3+5KeeheA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@styled-icons/bootstrap": "10.29.0",
+        "@styled-icons/boxicons-logos": "10.23.0",
+        "@styled-icons/boxicons-regular": "10.23.0",
+        "@styled-icons/boxicons-solid": "10.23.0",
+        "@styled-icons/crypto": "10.25.0",
+        "@styled-icons/entypo": "10.18.0",
+        "@styled-icons/entypo-social": "10.18.0",
+        "@styled-icons/evaicons-outline": "10.18.0",
+        "@styled-icons/evaicons-solid": "10.18.0",
+        "@styled-icons/evil": "10.18.0",
+        "@styled-icons/fa-brands": "10.26.0",
+        "@styled-icons/fa-regular": "10.26.0",
+        "@styled-icons/fa-solid": "10.26.0",
+        "@styled-icons/feather": "10.18.0",
+        "@styled-icons/fluentui-system-filled": "10.30.0",
+        "@styled-icons/fluentui-system-regular": "10.31.0",
+        "@styled-icons/foundation": "10.28.0",
+        "@styled-icons/heroicons-outline": "10.19.0",
+        "@styled-icons/heroicons-solid": "10.19.0",
+        "@styled-icons/icomoon": "10.18.0",
+        "@styled-icons/ionicons-outline": "10.28.0",
+        "@styled-icons/ionicons-sharp": "10.28.0",
+        "@styled-icons/ionicons-solid": "10.28.0",
+        "@styled-icons/material": "10.28.0",
+        "@styled-icons/material-outlined": "10.28.0",
+        "@styled-icons/material-rounded": "10.28.0",
+        "@styled-icons/material-sharp": "10.28.0",
+        "@styled-icons/material-twotone": "10.28.0",
+        "@styled-icons/octicons": "10.28.0",
+        "@styled-icons/open-iconic": "10.18.0",
+        "@styled-icons/remix-fill": "10.18.0",
+        "@styled-icons/remix-line": "10.18.0",
+        "@styled-icons/simple-icons": "10.29.0",
+        "@styled-icons/styled-icon": "10.6.3",
+        "@styled-icons/typicons": "10.18.0",
+        "@styled-icons/zondicons": "10.18.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "styled-reset": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "styled-components": "^5.2.1",
+    "styled-icons": "^10.31.0",
     "styled-reset": "^4.3.4",
     "tig": "^0.1.43",
     "web-vitals": "^1.1.1"

--- a/public/data/commentData.json
+++ b/public/data/commentData.json
@@ -1,0 +1,185 @@
+[
+  {
+    "id": 1,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMTAyMDNfMjY2/MDAxNjEyMzE3NDQ1NTAx.Oejtk7Y6zAvCrjhtND50c7JClIDq5g75DlJ391D3Rfkg.nukMbPmTeoKRGgSvfzBM9ZoF0JaqIw6Ge5TkWfncHHUg.PNG/p_56ffd2340d6c476da2f58c151e0205c2.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMTQw/MDAxNjAzNjg3Njg1NTI0.wN3aG5dn038IyVztmNHtkN_IDDsnGMWte0WPGIdWxrMg.n0Mg3OIeqt1vSZ0OHV8RYPRxYc9p19bUfH9T9MCrtnsg.PNG/d_5_dc2727e24e2f4741b4afde50f4f4a5f0.png",
+    "english_name": "Jordan 1 Retro High OG University Blue ",
+    "price": "450,000",
+    "is_wished": true,
+    "sizeModalList": [
+      { "id": 1, "size": 220 },
+      { "id": 2, "size": 225 },
+      { "id": 3, "size": 230 },
+      { "id": 4, "size": 235 },
+      { "id": 5, "size": 240 },
+      { "id": 6, "size": 245 },
+      { "id": 7, "size": 250 },
+      { "id": 8, "size": 255 },
+      { "id": 9, "size": 255 },
+      { "id": 10, "size": 260 },
+      { "id": 11, "size": 265 },
+      { "id": 12, "size": 270 },
+      { "id": 13, "size": 275 },
+      { "id": 14, "size": 280 },
+      { "id": 15, "size": 285 },
+      { "id": 16, "size": 290 },
+      { "id": 17, "size": 295 },
+      { "id": 18, "size": 300 }
+    ]
+  },
+  {
+    "id": 2,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEyMjhfMjcw/MDAxNjA5MTQxMzQ1ODE2.KoWVbwxPPVr_E2VIdtspSX_D0OYseewwgF2MrmCgHxEg.rlgpzHBNbIvwYhcrfRhvTAjyk2nLKyrsPeQOdn-3Ktog.PNG/p_c195a4c1e9fe4f379467e4cc0008efe8.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMTAzMTJfMTM5/MDAxNjE1NTE4MjM2NzA5.zSACpHizj3F43ShNk2jRb5T-heUgCIE-jRlqa2vIf7gg.NW_igMJbRCQK0-FSC20_98iw6o8-g0myWOT57hHm-Hgg.PNG/p_daf0e110ace349afb7b14b48faef2c9f.png",
+    "english_name": "Nike Dunk Low Retro Black ",
+    "price": "40,0000",
+    "is_wished": true
+  },
+  {
+    "id": 3,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEyMTFfMTM2/MDAxNjA3Njg0MTM5OTIy.rohM9HKBNoadw4VQnaAGO_3nbU4WWFcm_TzFP7_0TSUg.v_pmGEeR5-K0MXsHkrJKEgxvu1IjVYopqJmEIlUmN-gg.PNG/p_4b0f44f79d294081be5e6894fc98a1b5.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMTAzMTJfMTM5/MDAxNjE1NTE4MjM2NzA5.zSACpHizj3F43ShNk2jRb5T-heUgCIE-jRlqa2vIf7gg.NW_igMJbRCQK0-FSC20_98iw6o8-g0myWOT57hHm-Hgg.PNG/p_daf0e110ace349afb7b14b48faef2c9f.png",
+    "english_name": "(W) Nike Daybreak Summit White ",
+    "price": "390,000",
+    "is_wished": false
+  },
+  {
+    "id": 4,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjJfNjAg/MDAxNjAzMzMzOTcyOTQ5.uS-OjwboPjzbpdPjnLzmbLrgq3YtdjWaTCY-TT4K8Q4g.ZsK4IhODr6P0e2-c-kGxAj5R0hSFwcSE5mhGzzN70lkg.PNG/p_23523_0_df2fe8eaa2ae4d6aaa23b9eb5dac59f3.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMjU1/MDAxNjAzNjk3MzkyMDE1.PcUHGOhmH3AIspk3OYWmnahvsQ17mURyIV9BneJYwdAg.kdhD7L6qcbWvzSYeamjYf9tBr7l933U9yX5s8cTCVzEg.PNG/p_6_be683c1cec654dc08282a68156174127.png",
+    "english_name": "New Balance 992 Made in USA Grey (D Standard)",
+    "price": "250,000",
+
+    "is_wished": true
+  },
+  {
+    "id": 5,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMTAyMDNfMjY2/MDAxNjEyMzE3NDQ1NTAx.Oejtk7Y6zAvCrjhtND50c7JClIDq5g75DlJ391D3Rfkg.nukMbPmTeoKRGgSvfzBM9ZoF0JaqIw6Ge5TkWfncHHUg.PNG/p_56ffd2340d6c476da2f58c151e0205c2.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMTQw/MDAxNjAzNjg3Njg1NTI0.wN3aG5dn038IyVztmNHtkN_IDDsnGMWte0WPGIdWxrMg.n0Mg3OIeqt1vSZ0OHV8RYPRxYc9p19bUfH9T9MCrtnsg.PNG/d_5_dc2727e24e2f4741b4afde50f4f4a5f0.png",
+    "english_name": "Jordan 1 Retro High OG University Blue ",
+    "price": "450,000",
+    "is_wished": true
+  },
+  {
+    "id": 6,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEyMjhfMjcw/MDAxNjA5MTQxMzQ1ODE2.KoWVbwxPPVr_E2VIdtspSX_D0OYseewwgF2MrmCgHxEg.rlgpzHBNbIvwYhcrfRhvTAjyk2nLKyrsPeQOdn-3Ktog.PNG/p_c195a4c1e9fe4f379467e4cc0008efe8.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMTAzMTJfMTM5/MDAxNjE1NTE4MjM2NzA5.zSACpHizj3F43ShNk2jRb5T-heUgCIE-jRlqa2vIf7gg.NW_igMJbRCQK0-FSC20_98iw6o8-g0myWOT57hHm-Hgg.PNG/p_daf0e110ace349afb7b14b48faef2c9f.png",
+    "english_name": "Nike Dunk Low Retro Black ",
+    "price": "40,0000",
+    "is_wished": true
+  },
+  {
+    "id": 7,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEyMTFfMTM2/MDAxNjA3Njg0MTM5OTIy.rohM9HKBNoadw4VQnaAGO_3nbU4WWFcm_TzFP7_0TSUg.v_pmGEeR5-K0MXsHkrJKEgxvu1IjVYopqJmEIlUmN-gg.PNG/p_4b0f44f79d294081be5e6894fc98a1b5.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMTAzMTJfMTM5/MDAxNjE1NTE4MjM2NzA5.zSACpHizj3F43ShNk2jRb5T-heUgCIE-jRlqa2vIf7gg.NW_igMJbRCQK0-FSC20_98iw6o8-g0myWOT57hHm-Hgg.PNG/p_daf0e110ace349afb7b14b48faef2c9f.png",
+    "english_name": "(W) Nike Daybreak Summit White ",
+    "price": "390,000",
+    "is_wished": false
+  },
+  {
+    "id": 8,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjJfNjAg/MDAxNjAzMzMzOTcyOTQ5.uS-OjwboPjzbpdPjnLzmbLrgq3YtdjWaTCY-TT4K8Q4g.ZsK4IhODr6P0e2-c-kGxAj5R0hSFwcSE5mhGzzN70lkg.PNG/p_23523_0_df2fe8eaa2ae4d6aaa23b9eb5dac59f3.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMjU1/MDAxNjAzNjk3MzkyMDE1.PcUHGOhmH3AIspk3OYWmnahvsQ17mURyIV9BneJYwdAg.kdhD7L6qcbWvzSYeamjYf9tBr7l933U9yX5s8cTCVzEg.PNG/p_6_be683c1cec654dc08282a68156174127.png",
+    "english_name": "New Balance 992 Made in USA Grey (D Standard)",
+    "price": "250,000",
+    "is_wished": true
+  },
+  {
+    "id": 9,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMTAyMDNfMjY2/MDAxNjEyMzE3NDQ1NTAx.Oejtk7Y6zAvCrjhtND50c7JClIDq5g75DlJ391D3Rfkg.nukMbPmTeoKRGgSvfzBM9ZoF0JaqIw6Ge5TkWfncHHUg.PNG/p_56ffd2340d6c476da2f58c151e0205c2.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMTQw/MDAxNjAzNjg3Njg1NTI0.wN3aG5dn038IyVztmNHtkN_IDDsnGMWte0WPGIdWxrMg.n0Mg3OIeqt1vSZ0OHV8RYPRxYc9p19bUfH9T9MCrtnsg.PNG/d_5_dc2727e24e2f4741b4afde50f4f4a5f0.png",
+    "english_name": "Jordan 1 Retro High OG University Blue ",
+    "price": "450,000",
+    "is_wished": true
+  },
+
+  {
+    "id": 10,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEyMjhfMjcw/MDAxNjA5MTQxMzQ1ODE2.KoWVbwxPPVr_E2VIdtspSX_D0OYseewwgF2MrmCgHxEg.rlgpzHBNbIvwYhcrfRhvTAjyk2nLKyrsPeQOdn-3Ktog.PNG/p_c195a4c1e9fe4f379467e4cc0008efe8.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMTAzMTJfMTM5/MDAxNjE1NTE4MjM2NzA5.zSACpHizj3F43ShNk2jRb5T-heUgCIE-jRlqa2vIf7gg.NW_igMJbRCQK0-FSC20_98iw6o8-g0myWOT57hHm-Hgg.PNG/p_daf0e110ace349afb7b14b48faef2c9f.png",
+    "english_name": "Nike Dunk Low Retro Black ",
+    "price": "40,0000",
+    "is_wished": true
+  },
+  {
+    "id": 11,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEyMTFfMTM2/MDAxNjA3Njg0MTM5OTIy.rohM9HKBNoadw4VQnaAGO_3nbU4WWFcm_TzFP7_0TSUg.v_pmGEeR5-K0MXsHkrJKEgxvu1IjVYopqJmEIlUmN-gg.PNG/p_4b0f44f79d294081be5e6894fc98a1b5.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMTAzMTJfMTM5/MDAxNjE1NTE4MjM2NzA5.zSACpHizj3F43ShNk2jRb5T-heUgCIE-jRlqa2vIf7gg.NW_igMJbRCQK0-FSC20_98iw6o8-g0myWOT57hHm-Hgg.PNG/p_daf0e110ace349afb7b14b48faef2c9f.png",
+    "english_name": "(W) Nike Daybreak Summit White ",
+    "price": "390,000",
+    "is_wished": false
+  },
+  {
+    "id": 12,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjJfNjAg/MDAxNjAzMzMzOTcyOTQ5.uS-OjwboPjzbpdPjnLzmbLrgq3YtdjWaTCY-TT4K8Q4g.ZsK4IhODr6P0e2-c-kGxAj5R0hSFwcSE5mhGzzN70lkg.PNG/p_23523_0_df2fe8eaa2ae4d6aaa23b9eb5dac59f3.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMjU1/MDAxNjAzNjk3MzkyMDE1.PcUHGOhmH3AIspk3OYWmnahvsQ17mURyIV9BneJYwdAg.kdhD7L6qcbWvzSYeamjYf9tBr7l933U9yX5s8cTCVzEg.PNG/p_6_be683c1cec654dc08282a68156174127.png",
+    "english_name": "New Balance 992 Made in USA Grey (D Standard)",
+    "price": "250,000",
+    "is_wished": true
+  },
+  {
+    "id": 13,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMTAyMDNfMjY2/MDAxNjEyMzE3NDQ1NTAx.Oejtk7Y6zAvCrjhtND50c7JClIDq5g75DlJ391D3Rfkg.nukMbPmTeoKRGgSvfzBM9ZoF0JaqIw6Ge5TkWfncHHUg.PNG/p_56ffd2340d6c476da2f58c151e0205c2.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMTQw/MDAxNjAzNjg3Njg1NTI0.wN3aG5dn038IyVztmNHtkN_IDDsnGMWte0WPGIdWxrMg.n0Mg3OIeqt1vSZ0OHV8RYPRxYc9p19bUfH9T9MCrtnsg.PNG/d_5_dc2727e24e2f4741b4afde50f4f4a5f0.png",
+    "english_name": "Jordan 1 Retro High OG University Blue ",
+    "price": "450,000",
+    "is_wished": true
+  },
+
+  {
+    "id": 14,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEyMjhfMjcw/MDAxNjA5MTQxMzQ1ODE2.KoWVbwxPPVr_E2VIdtspSX_D0OYseewwgF2MrmCgHxEg.rlgpzHBNbIvwYhcrfRhvTAjyk2nLKyrsPeQOdn-3Ktog.PNG/p_c195a4c1e9fe4f379467e4cc0008efe8.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMTAzMTJfMTM5/MDAxNjE1NTE4MjM2NzA5.zSACpHizj3F43ShNk2jRb5T-heUgCIE-jRlqa2vIf7gg.NW_igMJbRCQK0-FSC20_98iw6o8-g0myWOT57hHm-Hgg.PNG/p_daf0e110ace349afb7b14b48faef2c9f.png",
+    "english_name": "Nike Dunk Low Retro Black ",
+    "price": "40,0000",
+    "is_wished": true
+  },
+  {
+    "id": 15,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEyMTFfMTM2/MDAxNjA3Njg0MTM5OTIy.rohM9HKBNoadw4VQnaAGO_3nbU4WWFcm_TzFP7_0TSUg.v_pmGEeR5-K0MXsHkrJKEgxvu1IjVYopqJmEIlUmN-gg.PNG/p_4b0f44f79d294081be5e6894fc98a1b5.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMTAzMTJfMTM5/MDAxNjE1NTE4MjM2NzA5.zSACpHizj3F43ShNk2jRb5T-heUgCIE-jRlqa2vIf7gg.NW_igMJbRCQK0-FSC20_98iw6o8-g0myWOT57hHm-Hgg.PNG/p_daf0e110ace349afb7b14b48faef2c9f.png",
+    "english_name": "(W) Nike Daybreak Summit White ",
+    "price": "390,000",
+    "is_wished": false
+  },
+  {
+    "id": 16,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjJfNjAg/MDAxNjAzMzMzOTcyOTQ5.uS-OjwboPjzbpdPjnLzmbLrgq3YtdjWaTCY-TT4K8Q4g.ZsK4IhODr6P0e2-c-kGxAj5R0hSFwcSE5mhGzzN70lkg.PNG/p_23523_0_df2fe8eaa2ae4d6aaa23b9eb5dac59f3.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMjU1/MDAxNjAzNjk3MzkyMDE1.PcUHGOhmH3AIspk3OYWmnahvsQ17mURyIV9BneJYwdAg.kdhD7L6qcbWvzSYeamjYf9tBr7l933U9yX5s8cTCVzEg.PNG/p_6_be683c1cec654dc08282a68156174127.png",
+    "english_name": "New Balance 992 Made in USA Grey (D Standard)",
+    "price": "250,000",
+    "is_wished": true
+  },
+  {
+    "id": 17,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjJfNjAg/MDAxNjAzMzMzOTcyOTQ5.uS-OjwboPjzbpdPjnLzmbLrgq3YtdjWaTCY-TT4K8Q4g.ZsK4IhODr6P0e2-c-kGxAj5R0hSFwcSE5mhGzzN70lkg.PNG/p_23523_0_df2fe8eaa2ae4d6aaa23b9eb5dac59f3.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMjU1/MDAxNjAzNjk3MzkyMDE1.PcUHGOhmH3AIspk3OYWmnahvsQ17mURyIV9BneJYwdAg.kdhD7L6qcbWvzSYeamjYf9tBr7l933U9yX5s8cTCVzEg.PNG/p_6_be683c1cec654dc08282a68156174127.png",
+    "english_name": "New Balance 992 Made in USA Grey (D Standard)",
+    "price": "250,000",
+    "is_wished": true
+  },
+  {
+    "id": 18,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjJfNjAg/MDAxNjAzMzMzOTcyOTQ5.uS-OjwboPjzbpdPjnLzmbLrgq3YtdjWaTCY-TT4K8Q4g.ZsK4IhODr6P0e2-c-kGxAj5R0hSFwcSE5mhGzzN70lkg.PNG/p_23523_0_df2fe8eaa2ae4d6aaa23b9eb5dac59f3.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMjU1/MDAxNjAzNjk3MzkyMDE1.PcUHGOhmH3AIspk3OYWmnahvsQ17mURyIV9BneJYwdAg.kdhD7L6qcbWvzSYeamjYf9tBr7l933U9yX5s8cTCVzEg.PNG/p_6_be683c1cec654dc08282a68156174127.png",
+    "english_name": "New Balance 992 Made in USA Grey (D Standard)",
+    "price": "250,000",
+    "is_wished": true
+  },
+  {
+    "id": 19,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjJfNjAg/MDAxNjAzMzMzOTcyOTQ5.uS-OjwboPjzbpdPjnLzmbLrgq3YtdjWaTCY-TT4K8Q4g.ZsK4IhODr6P0e2-c-kGxAj5R0hSFwcSE5mhGzzN70lkg.PNG/p_23523_0_df2fe8eaa2ae4d6aaa23b9eb5dac59f3.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMjU1/MDAxNjAzNjk3MzkyMDE1.PcUHGOhmH3AIspk3OYWmnahvsQ17mURyIV9BneJYwdAg.kdhD7L6qcbWvzSYeamjYf9tBr7l933U9yX5s8cTCVzEg.PNG/p_6_be683c1cec654dc08282a68156174127.png",
+    "english_name": "New Balance 992 Made in USA Grey (D Standard)",
+    "price": "250,000",
+    "is_wished": true
+  },
+  {
+    "id": 20,
+    "product_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjJfNjAg/MDAxNjAzMzMzOTcyOTQ5.uS-OjwboPjzbpdPjnLzmbLrgq3YtdjWaTCY-TT4K8Q4g.ZsK4IhODr6P0e2-c-kGxAj5R0hSFwcSE5mhGzzN70lkg.PNG/p_23523_0_df2fe8eaa2ae4d6aaa23b9eb5dac59f3.png?type=m",
+    "brand_image_url": "https://kream-phinf.pstatic.net/MjAyMDEwMjZfMjU1/MDAxNjAzNjk3MzkyMDE1.PcUHGOhmH3AIspk3OYWmnahvsQ17mURyIV9BneJYwdAg.kdhD7L6qcbWvzSYeamjYf9tBr7l933U9yX5s8cTCVzEg.PNG/p_6_be683c1cec654dc08282a68156174127.png",
+    "english_name": "New Balance 992 Made in USA Grey (D Standard)",
+    "price": "250,000",
+    "is_wished": true
+  }
+]

--- a/src/Pages/Shop/Components/ButtonPage.js
+++ b/src/Pages/Shop/Components/ButtonPage.js
@@ -1,0 +1,21 @@
+import React from "react";
+import styled from "styled-components";
+
+function ButtonPage({ handleBtn }) {
+  return <>{<ClickBtn onClick={handleBtn}>더보기</ClickBtn>}</>;
+}
+
+const ClickBtn = styled.div`
+  border: 1px solid black;
+  width: 120px;
+  height: 45px;
+  border-radius: 12px;
+  margin-top: 50px;
+  margin-left: 48%;
+  text-align: center;
+  line-height: 3;
+  font-size: 15px;
+  cursor: pointer;
+`;
+
+export default ButtonPage;

--- a/src/Pages/Shop/Components/Modal.js
+++ b/src/Pages/Shop/Components/Modal.js
@@ -1,0 +1,102 @@
+import React from "react";
+import styled from "styled-components";
+import ModalChild from "../Components/ModalChild";
+
+function Modal({ product_id, sizeList, handleCloseModal }) {
+  return (
+    <MainConteiner>
+      <InnerConteiner>
+        <Title>관심상품 추가</Title>
+
+        <Border></Border>
+        <GridBox>
+          {sizeList.map((el, idx) => (
+            <ModalChild
+              key={idx}
+              size_id={el.size_id}
+              size_name={el.size_name}
+              product_id={product_id}
+            />
+          ))}
+        </GridBox>
+        <Closed onClick={handleCloseModal}>확인</Closed>
+      </InnerConteiner>
+    </MainConteiner>
+  );
+}
+export default Modal;
+
+const GridBox = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 130px);
+  margin-left: 25px;
+  height: 300px;
+  overflow: hidden;
+  overflow: auto;
+`;
+
+const Closed = styled.div`
+  border: 1px solid black;
+  width: 120px;
+  height: 45px;
+  border-radius: 12px;
+  margin-left: 160px;
+  text-align: center;
+  line-height: 3;
+  font-size: 15px;
+  cursor: pointer;
+  margin-top: 20px;
+  position: absolute;
+`;
+
+const Border = styled.div`
+  border-bottom: ${props => props.theme.border.commonBorder};
+  height: 5;
+  height: 82px;
+`;
+const Title = styled.span`
+  font-size: 20px;
+  font-weight: 700;
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+`;
+const MainConteiner = styled.div`
+  z-index: 100;
+  position: fixed;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: rgba(34, 34, 34, 0.5);
+`;
+const InnerConteiner = styled.div`
+  border-radius: ${props => props.theme.border.otherRadius};
+  width: 440px;
+  height: 530px;
+  background-color: white;
+`;
+
+const SIZE = [
+  { id: 1, size: 220 },
+  { id: 2, size: 225 },
+  { id: 3, size: 230 },
+  { id: 4, size: 235 },
+  { id: 5, size: 240 },
+  { id: 6, size: 245 },
+  { id: 7, size: 250 },
+  { id: 8, size: 255 },
+  { id: 9, size: 255 },
+  { id: 10, size: 260 },
+  { id: 11, size: 265 },
+  { id: 12, size: 270 },
+  { id: 13, size: 275 },
+  { id: 14, size: 280 },
+  { id: 15, size: 285 },
+  { id: 16, size: 290 },
+  { id: 17, size: 295 },
+  { id: 18, size: 300 },
+];

--- a/src/Pages/Shop/Components/ModalChild.js
+++ b/src/Pages/Shop/Components/ModalChild.js
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import { VscBookmark } from "react-icons/vsc";
+import { IoBookmarkSharp } from "react-icons/io5";
+
+const ModalChild = ({ product_id, size_id, size_name, handleBookColor }) => {
+  const [bookmark, setBookmark] = useState(false);
+
+  const handleBookClick = () => {
+    fetch(`http://10.58.7.188:8000/product/${product_id}?size_id=${size_id}`, {
+      method: "POST",
+      headers: {
+        Authorization:
+          "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxfQ.IOGSFnezOAETXOTTFMJYwb7nv6lG14FqtahkW9ATL7s",
+      },
+    });
+    setBookmark(!bookmark);
+  };
+
+  return (
+    <Sizes>
+      {size_name}
+      <div
+        className="bookmarkIcon"
+        handleBookColor={handleBookColor}
+        onClick={handleBookClick}
+      >
+        {bookmark ? (
+          <IoBookmarkSharp className="bookmarkFillIcon" />
+        ) : (
+          <VscBookmark className="bookmarkIcon" />
+        )}
+      </div>
+    </Sizes>
+  );
+};
+
+const Sizes = styled.div`
+  border: 1px solid #d3d3d3;
+  border-radius: ${props => props.theme.border.productRadius};
+  width: 120px;
+  height: 50px;
+  text-align: center;
+  cursor: pointer;
+  margin: 5px;
+  border: 1px solid #d3d3d3;
+  border-radius: 12px;
+  background-color: white;
+  font-size: 14px;
+  margin-top: 10px;
+  padding-top: 10px;
+`;
+export default ModalChild;

--- a/src/Pages/Shop/Components/Product.js
+++ b/src/Pages/Shop/Components/Product.js
@@ -1,0 +1,135 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import Modal from "./Modal";
+import { VscBookmark } from "react-icons/vsc";
+import { IoBookmarkSharp } from "react-icons/io5";
+
+function Product({
+  setBookmark,
+  is_wished,
+  product_id,
+  product_image_url,
+  brand_image_url,
+  english_name,
+  price,
+  size_id,
+}) {
+  const [modal, setModal] = useState(false);
+  const [sizeList, setSizeList] = useState([]);
+  const [colorcheck, setColorCheck] = useState(false);
+  //
+  const history = useHistory();
+
+  const handleModal = () => {
+    // console.log("클릭1");
+    fetch(`http://10.58.7.188:8000/product/${product_id}`, {
+      headers: {
+        Authorization:
+          "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxfQ.IOGSFnezOAETXOTTFMJYwb7nv6lG14FqtahkW9ATL7s",
+      },
+    })
+      .then(res => res.json())
+      .then(res => {
+        setSizeList(res.result);
+      });
+    setModal(!modal);
+  };
+
+  const handleCloseModal = () => {
+    setModal(!modal);
+    setColorCheck(!colorcheck);
+  };
+
+  return (
+    <ProductBox>
+      <Box>
+        <div className="imgBox">
+          <img src={product_image_url} />
+        </div>
+        {modal ? (
+          <Modal
+            modal={modal}
+            handleCloseModal={handleCloseModal}
+            sizeList={sizeList}
+            product_image_url={product_image_url}
+            english_name={english_name}
+            product_id={product_id}
+          />
+        ) : null}
+        <Title>
+          <BrandBox>
+            <img src={brand_image_url} />
+            <span className="bookIcons">
+              {is_wished || colorcheck ? (
+                <IoBookmarkSharp />
+              ) : (
+                <VscBookmark onClick={handleModal} />
+              )}
+            </span>
+          </BrandBox>
+          <p className="engName">{english_name}</p>
+          <PriceTitle>{price}원</PriceTitle>
+          <PurchseTitle>즉시구매가</PurchseTitle>
+        </Title>
+      </Box>
+    </ProductBox>
+  );
+}
+
+const ProductBox = styled.div`
+  width: 280px;
+  height: 440px;
+
+  margin: 30px auto 0;
+  .bookIcons {
+    transform: translateX(30px);
+    font-size: 24px;
+  }
+`;
+
+const Box = styled.div`
+  border-radius: ${props => props.theme.border.productRadius};
+  background-color: ${props => props.theme.colors.backgroundPink};
+  height: 260px;
+
+  .imgBox {
+    width: 220px;
+    margin: 30px auto;
+  }
+`;
+
+const BrandBox = styled.div`
+  transform: translate(10px, 25px);
+  margin-top: 50px;
+  display: flex;
+  justify-content: space-between;
+
+  img {
+    width: auto;
+    height: 20px;
+  }
+`;
+
+const Title = styled.div`
+  width: 235px;
+  margin-top: -20px;
+  .engName {
+    padding: 20px 0 0;
+    height: 55px;
+    transform: translate(4px, 12px);
+  }
+`;
+
+const PriceTitle = styled.p`
+  font-weight: 700;
+  font-size: 15px;
+  line-height: 3;
+  bottom: 15px;
+  transform: translate(4px, 12px);
+`;
+const PurchseTitle = styled.p`
+  font-size: 11px;
+  color: #22222280;
+  transform: translate(4px, 10px);
+`;
+export default Product;

--- a/src/Pages/Shop/Components/ProductList.js
+++ b/src/Pages/Shop/Components/ProductList.js
@@ -1,0 +1,38 @@
+import React from "react";
+import Product from "../Components/Product";
+import styled from "styled-components";
+
+function ProductList({ shop }) {
+  return (
+    <MainBox>
+      <ProductContents>
+        {sortBy.map((el, idx) => {
+          return (
+            <Product
+              key={idx}
+              product_id={el.product_id}
+              product_image_url={el.product_image_url}
+              brand_image_url={el.brand_image_url}
+              english_name={el.english_name}
+              price={el.price}
+              is_wished={el.is_wished}
+              size_id={el.size_id}
+              getShop={getShop}
+            />
+          );
+        })}
+      </ProductContents>
+    </MainBox>
+  );
+}
+
+const MainBox = styled.div`
+  width: 1200px;
+  margin: auto;
+`;
+const ProductContents = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 300px);
+  grid-template-rows: repeat(5, 500px);
+`;
+export default ProductList;

--- a/src/Pages/Shop/Shop.js
+++ b/src/Pages/Shop/Shop.js
@@ -1,9 +1,409 @@
-import React, { Component } from "react";
+import React, { useState, useEffect, useRef } from "react";
+import styled from "styled-components";
+import ProductList from "../Shop/Components/ProductList";
+import ButtonPage from "../Shop/Components/ButtonPage";
+import { FaUndo } from "react-icons/fa";
+import { MdKeyboardArrowDown } from "react-icons/md";
+import { RiArrowUpDownLine } from "react-icons/ri";
 
-export class Shop extends Component {
-  render() {
-    return <div>sad</div>;
-  }
+const LIMIT = 20;
+function Shop() {
+  const dropdownRef = useRef(null);
+  const [isSugestActive, setIsSugestActive] = useState(dropdownRef, false); //인기 드롭다운
+  const [isActive, setIsActive] = useState(false); //첫번째 드롭
+  const [isSizeActive, setIsSizeActive] = useState(false); //두번째 드롭다운
+  const [isPriceActive, setIsPriceActive] = useState(false); //세번째 드롭다운
+  const [shop, setShop] = useState([]);
+  const [curruntIdx, setCurruntIdx] = useState(1);
+  const [solt, setSolt] = useState("인기순");
+  const [menusolt, setMenusolt] = useState("Popular");
+
+  const handleBtn = () => {
+    setCurruntIdx(curruntIdx + 1);
+
+    getShopList();
+  };
+
+  const handleFilter = () => {
+    setIsActive(!isActive);
+  };
+  const handleSizeFilter = () => {
+    setIsSizeActive(!isSizeActive);
+  };
+
+  const handlePrice = () => {
+    setIsPriceActive(!isPriceActive);
+  };
+  const handleSuggest = () => {
+    setIsSugestActive(!isSugestActive);
+  };
+  const handleSolt = e => {
+    setSolt(e.target.dataset.type);
+    setMenusolt(e.target.dataset.name);
+  };
+
+  useEffect(() => {
+    getShop();
+  }, []);
+
+  const getShopList = () => {
+    const offset = curruntIdx;
+    const query = `?limit=${LIMIT}&offset=${offset}`;
+    fetch(`http://10.58.7.188:8000/product${query}`)
+      .then(res => res.json())
+      .then(res => setShop([...shop, ...res.result]));
+  };
+
+  useEffect(() => {
+    setMenusolt();
+    fetch(`http://10.58.7.188:8000/product?sort=${menusolt}`, {
+      method: "GET",
+      headers: {
+        Authorization:
+          "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxfQ.IOGSFnezOAETXOTTFMJYwb7nv6lG14FqtahkW9ATL7s",
+      },
+    })
+      .then(res => res.json())
+      .then(res => setShop([...res.result]));
+  }, [menusolt]);
+
+  const getShop = () => {
+    fetch("http://10.58.7.188:8000/product", {
+      method: "GET",
+      headers: {
+        Authorization:
+          "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxfQ.IOGSFnezOAETXOTTFMJYwb7nv6lG14FqtahkW9ATL7s",
+      },
+    })
+      .then(res => res.json())
+      .then(res => setShop([...res.result]));
+  };
+
+  const sortList = [
+    { title: "인기순", value: "Popular" },
+    { title: "프리미엄순", value: "Premium" },
+    { title: "즉시 구매가순", value: "Newest" },
+    { title: "발매일순", value: "Price" },
+  ];
+
+  return (
+    shop.length !== 0 && (
+      <section>
+        <FilterBox>
+          <ResetBox>
+            <p className="resetIcons">
+              <FaUndo />
+            </p>
+            <span className="resetTitle">초기화</span>
+          </ResetBox>
+          <CategoryBox>
+            <Title>스니커즈</Title>
+            <span className="rowIcons">
+              <MdKeyboardArrowDown />
+            </span>
+          </CategoryBox>
+          <BrandContents>
+            <CategoryBox onClick={handleFilter}>
+              <Title>모든 브랜드</Title>
+              <span className="rowIcons">
+                <MdKeyboardArrowDown />
+              </span>
+              <nav className={`menu ${isActive ? "active" : ""}`}>
+                <ul>
+                  <li className="allBrand">모든 브랜드</li>
+                  <li>Jordan</li>
+                  <li>Nike</li>
+                  <li>Adidias</li>
+                  <li>Converse</li>
+                  <li>New Balance</li>
+                </ul>
+              </nav>
+            </CategoryBox>
+          </BrandContents>
+          <SizeContents>
+            <CategoryBox onClick={handleSizeFilter}>
+              <Title>모든 사이즈</Title>
+              <span className="rowIcons">
+                <MdKeyboardArrowDown />
+              </span>
+              <nav className={`SizeMenu ${isSizeActive ? "SizeActive" : ""}`}>
+                <ul>
+                  <li className="allBrand">모든 사이즈</li>
+                  <li>215mm</li>
+                  <li>220mm</li>
+                  <li>225mm</li>
+                  <li>230mm</li>
+                  <li>235mm</li>
+                  <li>240mm</li>
+                  <li>245mm</li>
+                  <li>250mm</li>
+                  <li>255mm</li>
+                  <li>260mm</li>
+                  <li>265mm</li>
+                  <li>270mm</li>
+                  <li>275mm</li>
+                  <li>280mm</li>
+                  <li>285mm</li>
+                  <li>290mm</li>
+                  <li>295mm</li>
+                  <li>300mm</li>
+                </ul>
+              </nav>
+            </CategoryBox>
+          </SizeContents>
+          <CategoryBox>
+            <PriceContents onClick={handlePrice}>
+              <Title>모든 가격</Title>
+              <span className="rowIcons">
+                <MdKeyboardArrowDown />
+              </span>
+              <nav
+                ref={dropdownRef}
+                className={`priceMenu ${isPriceActive ? "priceActive" : ""}`}
+              >
+                <ul>
+                  <li className="allBrand">모든 가격</li>
+                  <li>10만원 이하</li>
+                  <li>10만원 - 30만원 이하</li>
+                  <li>30만원 - 50만원 이하</li>
+                  <li>50만원 이상</li>
+                </ul>
+              </nav>
+            </PriceContents>
+            <RightBox>
+              <SugestContents onClick={handleSuggest}>
+                {/* 인기순 */}
+                {solt}
+                <RiArrowUpDownLine className="suggestIcons" />
+              </SugestContents>
+              <nav className={`sugMenu ${isSugestActive ? "sugActive" : ""}`}>
+                <ul>
+                  {sortList.map((el, idx) => (
+                    <li
+                      key={idx}
+                      name={el.title}
+                      data-type={el.title}
+                      onClick={handleSolt}
+                      data-name={el.value}
+                    >
+                      {el.title}
+                    </li>
+                  ))}
+                </ul>
+              </nav>
+            </RightBox>
+          </CategoryBox>
+        </FilterBox>
+        <ProductList shop={shop} solt={solt} getShop={getShop} />
+        <ButtonPage curruntIdx={curruntIdx} handleBtn={handleBtn} />
+      </section>
+    )
+  );
 }
+
+const RightBox = styled.div`
+  width: 100px;
+  margin-left: 1000px;
+  margin-top: 10px;
+  position: relative;
+  .sugMenu {
+    background: #ffffff;
+    position: absolute;
+    top: 60px;
+    width: 180px;
+    height: 210px;
+    box-shadow: 0 0px 0px 1px rgba(0, 0, 0, 0.1);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease;
+  }
+  .sugActive {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(-34px);
+    width: 220px;
+    padding: 10px;
+  }
+  .sugMenu ul {
+    font-size: 11px;
+    letter-spacing: -0.07px;
+    color: rgba(34, 34, 34, 0.8);
+    line-height: 2;
+    .allBrand {
+      font-weight: bold;
+      font-size: 13px;
+      color: #222222cc;
+    }
+  }
+  .sugMenu p {
+    font-size: 10px;
+    letter-spacing: -0.06px;
+    color: rgba(34, 34, 34, 0.5);
+  }
+`;
+
+const SugestContents = styled.p`
+  width: 100px;
+  display: flex;
+  margin-left: 150px;
+  margin-top: 15px;
+  color: #959595;
+  font-size: 13px;
+`;
+const PriceContents = styled.div`
+  position: relative;
+  .priceMenu {
+    background: #ffffff;
+    position: absolute;
+    top: 60px;
+    width: 180px;
+    height: 210px;
+    overflow: hidden;
+    overflow: auto;
+    box-shadow: 0 0px 0px 1px rgba(0, 0, 0, 0.1);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease;
+  }
+
+  .priceActive {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(-11px);
+  }
+  .priceMenu ul {
+    line-height: 2.5;
+    margin-left: 15px;
+    color: #222222cc;
+    .allBrand {
+      font-weight: bold;
+    }
+  }
+  .priceMenu li a {
+    color: #333333;
+    padding: 15px 20px;
+    display: block;
+  }
+`;
+const SizeContents = styled.div`
+  position: relative;
+
+  .SizeMenu {
+    background: #ffffff;
+    position: absolute;
+    top: 60px;
+    width: 180px;
+    height: 210px;
+    overflow: hidden;
+    overflow: auto;
+    box-shadow: 0 0px 0px 1px rgba(0, 0, 0, 0.1);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease;
+  }
+  .SizeActive {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(0px, -11px);
+  }
+  .SizeMenu ul {
+    line-height: 2.5;
+    margin-left: 15px;
+    color: #222222cc;
+    .allBrand {
+      font-weight: bold;
+    }
+  }
+  .SizeMenu li a {
+    color: #333333;
+    padding: 15px 20px;
+    display: block;
+  }
+`;
+
+const BrandContents = styled.div`
+  position: relative;
+
+  .menu {
+    background: #ffffff;
+    position: absolute;
+    top: 60px;
+    width: 180px;
+    height: 210px;
+    box-shadow: 0 0px 0px 1px rgba(0, 0, 0, 0.1);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.4s ease;
+  }
+  .menu.active {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(0px, -11px);
+  }
+  .menu ul {
+    line-height: 2.5;
+    margin-left: 15px;
+    color: #222222cc;
+    .allBrand {
+      font-weight: bold;
+    }
+  }
+  .menu li a {
+    color: #333333;
+    padding: 15px 20px;
+    display: block;
+  }
+`;
+const FilterBox = styled.div`
+  width: 100%;
+  position: fixed;
+  z-index: 90;
+  border: 1px solid #ebebeb;
+  background-color: #fff;
+  height: 50px;
+  display: flex;
+`;
+
+const ResetBox = styled.div`
+  border-left: 1px solid #ebebeb;
+  width: 120px;
+  height: 50px;
+  cursor: pointer;
+  .resetIcons {
+    position: absolute;
+    font-size: 13px;
+    transform: rotateY(180deg);
+    width: 55px;
+    margin-top: 15px;
+    font-weight: 1px;
+  }
+  .resetTitle {
+    font-size: 13px;
+    position: absolute;
+    transform: translate(65px, 15px);
+    color: #222222cc;
+  }
+`;
+
+const CategoryBox = styled.div`
+  border-right: 1px solid #ebebeb;
+  border-left: 1px solid #ebebeb;
+  width: 182px;
+  height: 50px;
+  cursor: pointer;
+  .rowIcons {
+    color: rgb(187, 187, 187);
+    position: absolute;
+    font-size: 25px;
+    transform: translate(140px, 10px);
+  }
+`;
+
+const Title = styled.span`
+  font-size: 13px;
+  position: absolute;
+  transform: translate(15px, 15px);
+  color: #222222cc;
+`;
 
 export default Shop;

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
 import Loading from "./Components/Loading/Loading";
 import Shop from "./Pages/Shop/Shop";
+import Modal from "./Pages/Shop/Components/Modal";
 import Login from "./Pages/Login/Login";
 import Join from "./Pages/Login/Join";
 import MyPage from "./Pages/MyPage/MyPage";

--- a/src/Styles/GlobalStyles.js
+++ b/src/Styles/GlobalStyles.js
@@ -29,6 +29,7 @@ const GlobalStyles = createGlobalStyle`
         cursor: pointer;
 
     }
+       
 `;
 
 export default GlobalStyles;

--- a/src/Styles/media.js
+++ b/src/Styles/media.js
@@ -1,0 +1,15 @@
+import { css } from "styled-components";
+
+const sizes = {
+  desktop: 1024,
+  tablet: 768,
+  mobile: 320,
+};
+export default Object.keys(sizes).reduce((acc, label) => {
+  acc[label] = (...args) => css`
+    @media (max-width: ${sizes[label]}px) {
+      ${css(...args)};
+    }
+  `;
+  return acc;
+}, {});


### PR DESCRIPTION
## 수정 사항 간략한 한줄 요약
- `필터` : 레이아웃 구현 완료
- `메인` : 레이아웃 구현 완료
- `모달` :  기능구현 
- `페이지네이션` 기능 구현 완료
- `필터` 레이아웃 구현 완료
- `정렬` 기능 완료
		 
## 수정 사항들 자세한 내용
-  `메인페이지` : 상품리스트를 `map` 으로 전달 해 백엔드와 통신 완료 했습니다.
- 함수형 컴포넌트 사용으로 `props`값을 전달받아 `모달` 을 구현 했습니다.
-  `페이지네이션` :  
 `limit` &`offset` 을 활용하여 백엔드와 통신까지 완료했습니다.
## 기타 질문 및 특이 사항
- `페이지네이션`:  보여주는 페이지가 누적 되어 나오기에
  `dataset` 을 사용하지 않고 구현했습니다.
`페이징네이션 리팩토링` :  함수를 하나의 함수로 만들라고 하셨는데,  이와 같은 방법으로 줄이는게 맞는지 궁금합니다.
 불필요한 코드를 어떻게 줄일 수 있을까요?
통신 할 부분은 주석처리 했습니다.


## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [x] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
- [x] Git rebase와 squash를 했고 커밋 수가 하나 인것을 확인 했습니다.
